### PR TITLE
Jest Can't Parse theme.js Import -- Unexpected Token in JSON at Position 0

### DIFF
--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/color/ColorCache.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/color/ColorCache.ts
@@ -12,7 +12,7 @@ const storageName = 'tinymce-custom-colors';
 
 export default (max: number = 10) => {
   const storageString = LocalStorage.getItem(storageName);
-  const localstorage = Type.isString(storageString) ? JSON.parse(storageString) : [];
+  const localstorage = Type.isString(storageString) ? JSON.parse(JSON.stringify(storageString)) : [];
 
   const prune = (list: string[]): string[] => {
     // When the localStorage cache is too big,


### PR DESCRIPTION
**What is the current behavior? Describe the bug**

https://github.com/tinymce/tinymce/issues/5279

My environment is using Jest, TS and the React TinyMCE editor. Using the component and silver theme, there is not an issue. When running Jest, there is an unexpected token in JSON at position 0 in silver/theme.js. The issue still persists when using the import and export loaders with webpack. I had to use a module transformer in Jest to get past the CSS issues, but its not possible to transform the theme.js file. This is a current roadblock to using TinyMCE. 

![image](https://user-images.githubusercontent.com/42361855/69446850-e6295280-0d1a-11ea-924c-0baa02398d0a.png)

I tracked the issue down to the ColorCache.ts file. 
I added a JSON.stringify to the storageString. This does not change the color functionality, editor behavior, and Jest now passes all tests and parses the silver/theme import without issues. 

![image](https://user-images.githubusercontent.com/42361855/69446444-0c022780-0d1a-11ea-8399-dc0c9a344963.png)

**Please provide the steps to reproduce and if possible a minimal demo of the problem via [fiddle.tinymce.com](http://fiddle.tinymce.com/) or similar.**

![image](https://user-images.githubusercontent.com/42361855/69447037-41f3db80-0d1b-11ea-8d47-8bcd740a7494.png)

**Fix:**

![image](https://user-images.githubusercontent.com/42361855/69447443-23daab00-0d1c-11ea-9dc3-945e61ecd890.png) 

**What is the expected behavior?**

There is no change to the functionality editor. Jest should be able to parse and handle the silver/theme.js import. 

**Which versions of TinyMCE, and which browser / OS are affected by this issue? Did this work in previous versions of TinyMCE?**

Issue found in version: 5.1.2
Issue persists in Windows and Linux. Prior version behavior is unknown. 